### PR TITLE
Fix typedoc links' deprecated syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,10 +68,11 @@
   "wireit": {
     "qa": {
       "dependencies": [
+        "packages:validate",
         "build",
         "test",
         "lint",
-        "packages:validate"
+        "docs"
       ]
     },
     "build": {

--- a/packages/queue/src/queue.ts
+++ b/packages/queue/src/queue.ts
@@ -48,10 +48,10 @@ class DefaultMessageQueue<Message> implements MessageQueue<Message> {
 }
 
 /**
- * Create a new [[MessageQueue]], with no backlog limits by default.
+ * Create a new {@link MessageQueue}, with no backlog limits by default.
  * @param messageBacklog Maximum backlog of waiting messages before [[send()]] returns `false`
  * @param receiverBacklog Maximum backlog of waiting receivers before [[receive()]] throws an Error
- * @returns a [[MessageQueue]] with the specified backlog limits
+ * @returns a {@link MessageQueue} with the specified backlog limits
  */
 export function createQueue<T>(
   messageBacklog?: number,

--- a/packages/store-edit/src/edit.ts
+++ b/packages/store-edit/src/edit.ts
@@ -2,13 +2,13 @@ import type { Immutable, RootState, Store } from "@lauf/store";
 import type { Editor } from "./types";
 import { produce } from "immer";
 
-/** Accepts an [[Editor]] function which will be passed a `draft` of the current
+/** Accepts an {@link Editor} function which will be passed a `draft` of the current
  * state. The function can manipulate the draft state using normal javascript
- * assignments and operations as if it ***wasn't*** [[Immutable]]. When it
- * returns, [[write]] will be called on your behalf with the equivalent
- * [[Immutable]] result.
+ * assignments and operations as if it ***wasn't*** {@link Immutable}. When it
+ * returns, {@link write} will be called on your behalf with the equivalent
+ * {@link Immutable} result.
  * @param editor A function to draft the next state
- * @returns The resulting new [[Immutable]] state aligned with your draft changes. */
+ * @returns The resulting new {@link Immutable} state aligned with your draft changes. */
 export function edit<State extends RootState>(
   store: Store<State>,
   editor: Editor<State>

--- a/packages/store-edit/src/types.ts
+++ b/packages/store-edit/src/types.ts
@@ -1,17 +1,17 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import type { Draft } from "immer";
 
-/**  A function passed to [[edit]]. The editor is called back with a
+/**  A function passed to {@link edit}. The editor is called back with a
  * `draft` - a mutable proxy of the Store's current `Immutable` `RootState`.
  *
  * You can make changes to the mutable `draft` proxy within your editor callback
  * using any javascript syntax. When it returns,
  * {@link https://immerjs.github.io/immer/ | Immer} efficiently composes a new
- * [[Immutable]] state to reflect your drafted changes, leaving the old state
+ * {@link Immutable} state to reflect your drafted changes, leaving the old state
  * intact. The new state is passed to [[Store.write]].
  *
  * The editor is equivalent to Immer's producer except returning a value doesn't
- * replace the [[RootState]]. To replace the state call [[Store.write]] instead
+ * replace the {@link RootState}. To replace the state call [[Store.write]] instead
  * of using an editor. This eliminates Immer's runtime errors when you **draft**
  * changes as well as returning a value, (easily done by accident in simple
  * arrow functions).
@@ -19,7 +19,7 @@ import type { Draft } from "immer";
  * See {@link https://immerjs.github.io/immer/ | Immer docs} for more detail on
  * the conventions for Immer `producers`.
  *
- * @param draft A mutable proxy of a [[Store]]'s existing `Immutable` state.
+ * @param draft A mutable proxy of a {@link Store}'s existing `Immutable` state.
  * Manipulate this object to compose the next state.
  * */
 export type Editor<T> = (draft: Draft<T>) => void;

--- a/packages/store-follow/README.md
+++ b/packages/store-follow/README.md
@@ -1,6 +1,6 @@
 # @lauf/store-follow
 
-Promise-oriented tracking to monitor selected parts of a @lauf/store [[Store]].
+Promise-oriented tracking to monitor selected parts of a @lauf/store {@link Store}.
 Re-runs a Selector after each change to store state, and notifies when the
 value returned by the Selector changes.
 

--- a/packages/store-follow/src/core.ts
+++ b/packages/store-follow/src/core.ts
@@ -4,8 +4,8 @@ import type { Controls, Follower, QueueHandler, ExitStatus } from "./types";
 import { createQueue } from "@lauf/queue";
 
 /**
- * Configures a [[MessageQueue]] that will receive messages with every new value
- * of a [[Selector]] against a [[Store]]. Passes the queue and the initial value
+ * Configures a {@link MessageQueue} that will receive messages with every new value
+ * of a {@link Selector} against a {@link Store}. Passes the queue and the initial value
  * from the Selector to `handleQueue` then waits for `handleQueue` to return,
  * after which the queue is unsubscribed.
  *

--- a/packages/store-follow/src/types.ts
+++ b/packages/store-follow/src/types.ts
@@ -16,7 +16,7 @@ export type Follower<Selected, Ending> = (
   // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 ) => Promise<void | ExitStatus>;
 
-/** A control object for a [[Follower]] function to signal
+/** A control object for a {@link Follower} function to signal
  * exit behaviour, retrieve references.
  */
 export interface Controls<Selected, Ending> {

--- a/packages/store-react/README.md
+++ b/packages/store-react/README.md
@@ -65,7 +65,7 @@ const rootState = useRootState(props.store);
 Note, this is rarely needed in production code for several reasons...
 
 - well-architected business logic should live outside the render loop, using `followSelector(...)` from @lauf/store-follow
-- to consume **part** of the state, prefer [[useSelector]] which doesn't trigger renders on every state change
+- to consume **part** of the state, prefer {@link useSelector} which doesn't trigger renders on every state change
 
 ```typescript
 // Re-runs this functional component when any state changes

--- a/packages/store-react/src/index.ts
+++ b/packages/store-react/src/index.ts
@@ -8,14 +8,14 @@ import { createStore } from "@lauf/store";
 import { useState, useEffect } from "react";
 
 /** When the component is first mounted, this hook creates and returns a a new
- * long-lived [[Store]] initialised with `initialState`.
+ * long-lived {@link Store} initialised with `initialState`.
  *
  * In later renders the hook will always return the same `Store`, It
  * deliberately doesn't force a component refresh when the Store state changes.
- * To track changes in the store, see [[useSelected]] or [[useRootState]].
+ * To track changes in the store, see {@link useSelected} or {@link useRootState}.
  *
  * @param initialState
- * @returns A lazily-created [[Store]]
+ * @returns A lazily-created {@link Store}
  */
 export function useStore<T extends RootState>(initialState: Immutable<T>) {
   const [store] = useState(() => {
@@ -25,7 +25,7 @@ export function useStore<T extends RootState>(initialState: Immutable<T>) {
 }
 
 /** A hook for tracking a subpart or a computed value derived from the
- * [[RootState]] of a [[Store]] by a [[Selector]] function.
+ * {@link RootState} of a {@link Store} by a {@link Selector} function.
  *
  * This hook calls `selector` with the `Store`'s `RootState` and returns the
  * derived value. Then it [[Watcher|watches]] the store, calling the `selector`
@@ -34,13 +34,13 @@ export function useStore<T extends RootState>(initialState: Immutable<T>) {
  * triggered (and this hook will return the new value).
  *
  * If your `selector` constructs a new data structure based on the `RootState`,
- * (rather than just selecting some part of the [[Immutable]] `RootState` or
+ * (rather than just selecting some part of the {@link Immutable} `RootState` or
  * calculating a primitive value), then it might return a non-identical value
  * even when nothing has changed. Computed data structures should be
  * [memoized](https://github.com/reduxjs/reselect#creating-a-memoized-selector)
  * to minimise component refreshes.
  *
- * See [[Selector]]
+ * See {@link Selector}
  */
 export function useSelected<State extends RootState, Selected>(
   store: Store<State>,
@@ -63,10 +63,10 @@ export function useSelected<State extends RootState, Selected>(
   return selected;
 }
 
-/** A hook for tracking the [[RootState]] of a [[Store]]. Note, this forces a reload
+/** A hook for tracking the {@link RootState} of a {@link Store}. Note, this forces a reload
  * of the component when ***any*** part of the state tree changes. You probably want
- * [[useSelected]] instead.
- * @param store The [[Store]] to track.
+ * {@link useSelected} instead.
+ * @param store The {@link Store} to track.
  */
 export function useRootState<State extends RootState>(store: Store<State>) {
   const { read, watch } = store;

--- a/packages/store/src/lib/partition.ts
+++ b/packages/store/src/lib/partition.ts
@@ -7,7 +7,7 @@ import type {
 } from "../types";
 import { DefaultWatchable } from "./watchable";
 
-/** Utility class for partitioning of a Store. See [[createStorePartition]]. */
+/** Utility class for partitioning of a Store. See {@link createStorePartition}. */
 class DefaultStorePartition<
     ParentState extends PartitionableState<Key>,
     Key extends keyof ParentState
@@ -58,8 +58,8 @@ class DefaultStorePartition<
 }
 
 /**
- * Constructs a [[Store]] that tracks a child property of another store's
- * [[RootState]]. See [[PartitionableState]] for more details.
+ * Constructs a {@link Store} that tracks a child property of another store's
+ * {@link RootState}. See {@link PartitionableState} for more details.
  *
  * @param store The parent store containing the partition
  * @param key The child key to partition the parent's state.

--- a/packages/store/src/lib/store.ts
+++ b/packages/store/src/lib/store.ts
@@ -4,15 +4,15 @@ import { DefaultWatchableState } from "./watchableState";
 
 // commented
 
-/** Reference implementation of Lauf [[Store]]  */
+/** Reference implementation of Lauf {@link Store}  */
 class DefaultStore<State extends RootState>
   extends DefaultWatchableState<Immutable<State>>
   implements Store<State> {}
 
-/** Initialise a [[Store]] with an [[Immutable]] initial [[RootState]] - any
+/** Initialise a {@link Store} with an {@link Immutable} initial {@link RootState} - any
  * array, tuple or object. This state can be updated and monitored for updates
  * to drive an app.
- * @param initialState - The initial [[RootState]] stored
+ * @param initialState - The initial {@link RootState} stored
  * @param watchers - A list of [[Watcher|Watchers]] to be notified once and permanently subscribed
  * @category
  */

--- a/packages/store/src/types/immutable.ts
+++ b/packages/store/src/types/immutable.ts
@@ -4,8 +4,8 @@
  * special objects and methods and typically doesn't require you to change your
  * code.
  *
- * It is used to flag and enforce immutability of a [[RootState]] and its
- * descendants - values assigned to a [[Store]] ([[Store.write]]) or retrieved
+ * It is used to flag and enforce immutability of a {@link RootState} and its
+ * descendants - values assigned to a {@link Store} ([[Store.write]]) or retrieved
  * from it ([[Store.read]]). The type `Immutable<T>` is equivalent to applying
  * `Readonly<T>` to `T` and its descendant properties, telling the compiler that
  * no change should be made anywhere in a Store's state tree.
@@ -28,7 +28,7 @@ export type Immutable<T> = T extends (...args: unknown[]) => unknown
   ? ImmutableIndex<T>
   : T;
 
-/** Recursive Readonly implementation for any (indexable) [[RootState]] such as
+/** Recursive Readonly implementation for any (indexable) {@link RootState} such as
  * an array or object */
 type ImmutableIndex<T> = Readonly<{
   [K in keyof T]: Immutable<T[K]>;

--- a/packages/store/src/types/store.ts
+++ b/packages/store/src/types/store.ts
@@ -1,17 +1,17 @@
 import type { Immutable } from "./immutable";
 import type { WatchableState } from "./watchable";
 
-/** A `Store` keeps an Immutable [[RootState]] - any array, tuple or object -
+/** A `Store` keeps an Immutable {@link RootState} - any array, tuple or object -
  * which can be changed and monitored for changes to drive an app. Make a new
- * `Store` by calling [[createStore]] with an `initialState`.
+ * `Store` by calling {@link createStore} with an `initialState`.
  *
- * Flagging all state references as [[Immutable]] guides IDEs to treat these as
+ * Flagging all state references as {@link Immutable} guides IDEs to treat these as
  * [Immutable Objects]{@link https://en.wikipedia.org/wiki/Immutable_object} to
  * avoid programming errors.
  *
  * ## Watching State
  *
- * Assigning a new [[Immutable]] `RootState` using [[Store.write]] notifies
+ * Assigning a new {@link Immutable} `RootState` using [[Store.write]] notifies
  * [[Watcher|Watchers]] previously subscribed using [[Store.watch]]. This
  * mechanism ensures that app logic and renderers can track the latest state.
  *
@@ -42,35 +42,35 @@ import type { WatchableState } from "./watchable";
  */
 export type Store<State extends RootState> = WatchableState<Immutable<State>>;
 
-/** Defines the set of possible state types for a [[Store]],
+/** Defines the set of possible state types for a {@link Store},
  * usually the top level State 'container' is either an
  * Array, Tuple, or keyed Object */
 export type RootState = object;
 
-/** A Selector derives some sub-part or computed value from a [[RootState]] in a
- * @lauf/store [[Store]]. `Object.is(prev, next)` is normally used to compare
+/** A Selector derives some sub-part or computed value from a {@link RootState} in a
+ * @lauf/store {@link Store}. `Object.is(prev, next)` is normally used to compare
  * with the previous resultfrom the same Selector to monitor if some part has
  * changed, defining when app logic should be re-run. */
 export type Selector<State extends RootState, Selected> = (
   state: Immutable<State>
 ) => Immutable<Selected>;
 
-/** An item satisfying type constraints of [[RootState]] but where a child item
+/** An item satisfying type constraints of {@link RootState} but where a child item
  * at `Key` ***also*** satisfies `RootState`. A Store with a
- * [[PartitionableState]] can therefore be partitioned into a child [[Store]] by
+ * {@link PartitionableState} can therefore be partitioned into a child {@link Store} by
  * `Key`.
  *
- * Partitioning enables hierarchy and logical isolation of a [[Store]], so that
+ * Partitioning enables hierarchy and logical isolation of a {@link Store}, so that
  * higher-level stores can be composed of multiple lower-level stores. Logic
  * relying on some `Store<T>` need not know whether `<T>` is the whole app state
  * or just some part of it.
  *
  * Partitioning can also make eventing more efficient. When a parent Store's
  * `RootState` changes, implementations can omit notifications for all
- * [[Watcher|Watchers]] of a child partition if the child [[RootState]] has not
+ * [[Watcher|Watchers]] of a child partition if the child {@link RootState} has not
  * changed, meaning no value within the child partition has changed.
  *
- * See also [[createStorePartition]].
+ * See also {@link createStorePartition}.
  */
 export type PartitionableState<Key extends string | number | symbol> =
   RootState & { [k in Key]: RootState };

--- a/packages/store/src/types/watchable.ts
+++ b/packages/store/src/types/watchable.ts
@@ -4,7 +4,7 @@ export type Watcher<T> = (item: T) => unknown;
 /** Handle returned from [[Watchable.watch]] that can disable an earlier subscription. */
 export type Unwatch = () => void;
 
-/** A subscribable object, accepts [[Watcher]] callbacks, sends notifications of
+/** A subscribable object, accepts {@link Watcher} callbacks, sends notifications of
  * type T . */
 export interface Watchable<T> {
   /** Subscribes `watcher` to receive notifications.
@@ -15,7 +15,7 @@ export interface Watchable<T> {
   watch: (watcher: Watcher<T>) => Unwatch;
 }
 
-/** A [[Watchable]] encapsulating a changing value which you can [[write]] and [[read]].
+/** A {@link Watchable} encapsulating a changing value which you can {@link write} and {@link read}.
  * @typeParam T The value stored, retrieved and watched.
  */
 export interface WatchableState<T> extends Watchable<T> {


### PR DESCRIPTION
Since https://github.com/TypeStrong/typedoc/blob/3830f9650ec7d2bc5e7b53bd28898f23fc6c5590/CHANGELOG.md#v0230-2022-06-26 typedoc retired the syntax we were using for relative documentation links.

This resulted in documentation like this, in which square brackets appear as literals and no links are resolved...

![image](https://user-images.githubusercontent.com/159819/233835186-10fae6dd-e5de-4551-b804-edacd0a06a0d.png)
