### PR TITLE
Finalise counter apps and their READMEs

### DIFF
--- a/apps/counter-dom-commonjs/README.md
+++ b/apps/counter-dom-commonjs/README.md
@@ -1,3 +1,3 @@
-This is an example app from the @lauf project.
+# Counter (ESM Javascript)
 
-It should be possible to check out this folder directly from github and build it in isolation, when it will install @lauf dependencies from npm directly. However it is built and tested within the @lauf monorepo, when it resolves to local packages.
+This is identical to the [Typescript DOM app](https://github.com/cefn/lauf/tree/main/apps/counter-dom-ts) but is authored using CommonJS using `require` in Javascript.

--- a/apps/counter-dom-esm/.eslintrc.cjs
+++ b/apps/counter-dom-esm/.eslintrc.cjs
@@ -1,2 +1,5 @@
 const rootConfig = require("../../.eslintrc.cjs");
-module.exports = rootConfig;
+module.exports = {
+  ...rootConfig,
+  ignorePatterns: [...rootConfig.ignorePatterns, "vite.config.ts"],
+};

--- a/apps/counter-dom-esm/README.md
+++ b/apps/counter-dom-esm/README.md
@@ -1,3 +1,3 @@
-This is an example app from the @lauf project.
+# Counter (ESM Javascript)
 
-It should be possible to check out this folder directly from github and build it in isolation, when it will install @lauf dependencies from npm directly. However it is built and tested within the @lauf monorepo, when it resolves to local packages.
+This is identical to the [Typescript DOM app](https://github.com/cefn/lauf/tree/main/apps/counter-dom-ts) but is authored using ECMAScript Modules (ESM) using `import` in Javascript.

--- a/apps/counter-dom-esm/vite.config.ts
+++ b/apps/counter-dom-esm/vite.config.ts
@@ -1,21 +1,18 @@
 import { defineConfig } from "vite";
 import legacy from "@vitejs/plugin-legacy";
-import vitePluginCommonjs from "vite-plugin-commonjs";
-import rollupPluginCommonjs from "@rollup/plugin-commonjs";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   build: {
     minify: "terser",
     rollupOptions: {
-      plugins: [rollupPluginCommonjs()],
+      treeshake: true,
     },
   },
   plugins: [
     legacy({
       targets: ["defaults"],
     }),
-    vitePluginCommonjs(),
   ],
   clearScreen: false,
 });

--- a/apps/counter-dom-tiny/README.md
+++ b/apps/counter-dom-tiny/README.md
@@ -1,4 +1,4 @@
-This Counter app is identical to the other ones, but tuned for the tiniest possible bundle. The result is a bundle of just 406 bytes combining the fully reactive `@lauf/store` state library and the app logic.
+This Counter app is identical to the other ones, but tuned for the tiniest possible bundle. The result is a bundle of just 424 bytes combining the fully reactive `@lauf/store` state library and the app logic.
 
 - Like all counter-dom-\* apps this uses the dom directly, avoiding the (~45k gzip) overhead of React
 - It doesn't use the promise support of a `@lauf/store-follow` queue. It uses watcher callbacks instead.

--- a/apps/counter-dom-ts/README.md
+++ b/apps/counter-dom-ts/README.md
@@ -1,3 +1,21 @@
-This is an example app from the @lauf project.
+# Counter (Optimised Typescript)
 
-It should be possible to check out this folder directly from github and build it in isolation, when it will install @lauf dependencies from npm directly. However it is built and tested within the @lauf monorepo, when it resolves to local packages.
+This is the Typescript reference counter app behaves just like the [React Typescript version](https://github.com/cefn/lauf/tree/main/apps/counter-react-ts), [React Javascript version](https://github.com/cefn/lauf/tree/main/apps/counter-react-js) and the [Preact version](https://github.com/cefn/lauf/tree/main/apps/counter-preact-ts).
+
+However, it illustrates how managing state in a dedicated Store, independently of any web framework, allows you ultimate flexibility. This implementation directly manipulates the DOM when app state changes, without any JSX component framework at all!
+
+The result is a build which, even with polyfills to target the default [browserslist](https://browsersl.ist/) is radically smaller than anything built with React or Preact.
+
+From this reference application, we have derived an ESM Javascript build and a CommonJS Javascript Build which are authored without any Typescript annotations. We also derive an optimised build which attempts to create the smallest possible bundle size. You can see the byte count for each javascript bundle size below.
+
+The smallest version of the `dom` app collectionj - `counter-dom-tiny` - bundles no polyfills, and targets only modern browsers. It can build the complete app in just 424 bytes! That's **235 times smaller** than the equivalent React app.
+
+The `ESM Javascript` and `Typescript` bundles neck-and-neck at nearly **80 times smaller** than the React version thanks to effective tree-shaking removing unused symbols. However, even the wasteful commonjs bundle is still nearly **11 times smaller**.
+
+```zsh
+watchable git:(main) ✗ find -type d -iname 'counter*dom*' | xargs -I{} zsh -c "echo -n '{} '; cd {}; cat dist/assets/*.js | gzip | wc -c" | sort -n -k2
+./apps/counter-dom-tiny 424
+./apps/counter-dom-esm 1282
+./apps/counter-dom-ts 1282
+./apps/counter-dom-commonjs 9319
+```

--- a/apps/counter-dom-ts/vite.config.ts
+++ b/apps/counter-dom-ts/vite.config.ts
@@ -1,21 +1,18 @@
 import { defineConfig } from "vite";
 import legacy from "@vitejs/plugin-legacy";
-import vitePluginCommonjs from "vite-plugin-commonjs";
-import rollupPluginCommonjs from "@rollup/plugin-commonjs";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   build: {
     minify: "terser",
     rollupOptions: {
-      plugins: [rollupPluginCommonjs()],
+      treeshake: true,
     },
   },
   plugins: [
     legacy({
       targets: ["defaults"],
     }),
-    vitePluginCommonjs(),
   ],
   clearScreen: false,
 });

--- a/apps/counter-preact-ts/README.md
+++ b/apps/counter-preact-ts/README.md
@@ -1,9 +1,25 @@
-# Counter (Typescript)
+# Counter (Preact with Typescript)
 
-This minimal Typescript app shows how to bind React views and controls to shared state that is managed independently of React. See also the [Javascript version of this app](../../apps/counter-js)
+This is identical to the [React version of this app](https://github.com/cefn/lauf/tree/main/apps/counter-react-ts) as a demonstration that [@lauf/store-react](https://www.npmjs.com/package/@lauf/store-react) also works with [Preact](https://preactjs.com/).
 
-Use `npm install` then `npm run dev` to demo the application locally. To run the code in an editable sandbox visit https://stackblitz.com/github/cefn/watchable/tree/alpha-release/apps/counter-react-ts?file=README.md
+The gzipped bundle size with Preact is tiny, with the same app bundled in React being 6 times bigger!
 
-See [logic.ts](https://github.com/cefn/lauf/tree/main/apps/counter/src/logic.ts) and [ui.tsx](https://github.com/cefn/lauf/tree/main/apps/counter/src/ui.tsx) to understand how it works.
+This command line reports on built assets, targeting the default [browserslist](https://browsersl.ist/)
+
+```
+watchable git:(main) ✗ ls -1 apps/counter*react-ts/dist/assets/*.js | xargs -I{} zsh -c "echo {}; cat {} | wc -c"
+apps/counter-preact-ts/dist/assets/index-b24b95cf.js
+24605
+apps/counter-preact-ts/dist/assets/index-legacy-391f2bee.js
+23910
+apps/counter-preact-ts/dist/assets/polyfills-legacy-823a12e6.js
+18698
+apps/counter-react-ts/dist/assets/index-cf510a1e.js
+143388
+apps/counter-react-ts/dist/assets/index-legacy-4b55f219.js
+142948
+apps/counter-react-ts/dist/assets/polyfills-legacy-fc8e3fef.js
+22348
+```
 
 This project builds and runs using [Vite](https://vitejs.dev/).

--- a/apps/counter-preact-ts/package.json
+++ b/apps/counter-preact-ts/package.json
@@ -36,7 +36,6 @@
     "@types/react": "^18.0.34",
     "@types/react-dom": "^18.0.11",
     "@vitejs/plugin-legacy": "^4.0.2",
-    "@vitejs/plugin-react": "^3.1.0",
     "npm-run-all": "^4.1.5",
     "playwright-chromium": "^1.32.3",
     "typescript": "^5.0.4",

--- a/apps/counter-react-js/README.md
+++ b/apps/counter-react-js/README.md
@@ -1,3 +1,11 @@
-This is an example app from the @lauf project.
+# Counter (Javascript)
 
-It should be possible to check out this folder directly from github and build it in isolation, when it will install @lauf dependencies from npm directly. However it is built and tested within the @lauf monorepo, when it resolves to local packages.
+This minimal Javascript app shows how to bind React views and controls to shared state that is managed independently of React. See also the [Typescript version of this app](https://github.com/cefn/lauf/tree/main/apps/counter-react-ts)
+
+To run the code in an editable sandbox visit https://stackblitz.com/github/cefn/watchable/tree/main/apps/counter-react-js?file=src/ui.tsx
+
+Use `npm install` then `npm run dev` to demo the application locally.
+
+See [logic.ts](https://github.com/cefn/lauf/tree/main/apps/counter-react-js/src/logic.ts) and [ui.tsx](https://github.com/cefn/lauf/tree/main/apps/counter-react-js/src/ui.tsx) to understand how it works.
+
+This project builds and runs using [Vite](https://vitejs.dev/).

--- a/apps/counter-react-js/vite.config.ts
+++ b/apps/counter-react-js/vite.config.ts
@@ -1,7 +1,20 @@
 import { defineConfig } from "vite";
+import legacy from "@vitejs/plugin-legacy";
 import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  build: {
+    minify: "terser",
+    rollupOptions: {
+      treeshake: true,
+    },
+  },
+  plugins: [
+    react(),
+    legacy({
+      targets: ["defaults"],
+    }),
+  ],
+  clearScreen: false,
 });

--- a/apps/counter-react-ts-edit-context/README.md
+++ b/apps/counter-react-ts-edit-context/README.md
@@ -1,11 +1,3 @@
-# Counter (Typescript)
+# Counter (Typescript with @lauf/store-edit)
 
-This simple Typescript app defines shared state independently of React, then binds React views and controls to it. See also the [Javascript version of this app](../../apps/counter-js)
-
-To run the code in an editable sandbox visit https://stackblitz.com/github/cefn/watchable/tree/alpha-release/apps/counter-react-ts?file=README.md
-
-See [logic.ts](https://github.com/cefn/lauf/tree/main/apps/counter/src/logic.ts) and [ui.tsx](https://github.com/cefn/lauf/tree/main/apps/counter/src/ui.tsx) to understand how it works.
-
-Use `npm install` then `npm run start` to demo the application locally.
-
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+This is identical to the [Edit counter app](https://github.com/cefn/lauf/tree/main/apps/counter-react-ts-edit) except it uses the [React Context API](https://react.dev/reference/react#context-hooks) to avoid [prop drilling](https://kentcdodds.com/blog/prop-drilling).

--- a/apps/counter-react-ts-edit/README.md
+++ b/apps/counter-react-ts-edit/README.md
@@ -1,9 +1,3 @@
-# Counter (Typescript)
+# Counter (Typescript with @lauf/store-edit)
 
-This minimal Typescript app shows how to bind React views and controls to shared state that is managed independently of React. See also the [Javascript version of this app](../../apps/counter-js)
-
-Use `npm install` then `npm run dev` to demo the application locally. To run the code in an editable sandbox visit https://stackblitz.com/github/cefn/watchable/tree/alpha-release/apps/counter-react-ts?file=README.md
-
-See [logic.ts](https://github.com/cefn/lauf/tree/main/apps/counter/src/logic.ts) and [ui.tsx](https://github.com/cefn/lauf/tree/main/apps/counter/src/ui.tsx) to understand how it works.
-
-This project builds and runs using [Vite](https://vitejs.dev/).
+This is identical to the [Standard counter app](https://github.com/cefn/lauf/tree/main/apps/counter-react-ts) except it uses [@lauf/store-edit](https://www.npmjs.com/package/@lauf/store-edit) to avoid the developer having to learn and follow [Immutable update patterns](https://redux.js.org/usage/structuring-reducers/immutable-update-patterns).

--- a/apps/counter-react-ts/README.md
+++ b/apps/counter-react-ts/README.md
@@ -1,9 +1,11 @@
 # Counter (Typescript)
 
-This minimal Typescript app shows how to bind React views and controls to shared state that is managed independently of React. See also the [Javascript version of this app](../../apps/counter-js)
+This minimal Typescript app shows how to bind React views and controls to shared state that is managed independently of React. See also the [Javascript version of this app](https://github.com/cefn/lauf/tree/main/apps/counter-react-js)
 
-Use `npm install` then `npm run dev` to demo the application locally. To run the code in an editable sandbox visit https://stackblitz.com/github/cefn/watchable/tree/alpha-release/apps/counter-react-ts?file=README.md
+To run the code in an editable sandbox visit https://stackblitz.com/github/cefn/watchable/tree/main/apps/counter-react-ts?file=src/ui.tsx
 
-See [logic.ts](https://github.com/cefn/lauf/tree/main/apps/counter/src/logic.ts) and [ui.tsx](https://github.com/cefn/lauf/tree/main/apps/counter/src/ui.tsx) to understand how it works.
+Use `npm install` then `npm run dev` to demo the application locally.
+
+See [logic.ts](https://github.com/cefn/lauf/tree/main/apps/counter-react-ts/src/logic.ts) and [ui.tsx](https://github.com/cefn/lauf/tree/main/apps/counter-react-ts/src/ui.tsx) to understand how it works.
 
 This project builds and runs using [Vite](https://vitejs.dev/).

--- a/package-lock.json
+++ b/package-lock.json
@@ -130,7 +130,6 @@
         "@types/react": "^18.0.34",
         "@types/react-dom": "^18.0.11",
         "@vitejs/plugin-legacy": "^4.0.2",
-        "@vitejs/plugin-react": "^3.1.0",
         "npm-run-all": "^4.1.5",
         "playwright-chromium": "^1.32.3",
         "typescript": "^5.0.4",


### PR DESCRIPTION
Add READMEs for all apps, illustrating their purpose and describing experimental results.

Configure everything but '-tiny' to bundle for legacy browsers to enable better comparisons between apps.