### PR TITLE
Don't wrap Selected in Immutable

### DIFF
--- a/packages/store-follow/src/core.ts
+++ b/packages/store-follow/src/core.ts
@@ -22,11 +22,11 @@ export async function withSelectorQueue<
 >(
   store: Store<State>,
   selector: Selector<State, Selected>,
-  handleQueue: QueueHandler<Immutable<Selected>, Ending>
+  handleQueue: QueueHandler<Selected, Ending>
 ): Promise<Ending> {
-  const queue = createQueue<Immutable<Selected>>();
+  const queue = createQueue<Selected>();
   // Could be hoisted as a 'SelectorWatchable'
-  let prevSelected: Immutable<Selected> = selector(store.read());
+  let prevSelected: Selected = selector(store.read());
   const selectedNotifier = (value: Immutable<State>) => {
     const nextSelected = selector(value);
     if (!Object.is(nextSelected, prevSelected)) {
@@ -71,7 +71,7 @@ export async function followSelector<State extends RootState, Selected, Ending>(
     async function (queue, selected) {
       const { receive } = queue;
       let result: Ending;
-      let lastSelected: Immutable<Selected> | undefined;
+      let lastSelected: Selected | undefined;
       const exitStatus: ExitStatus = ["exit"];
       const controls: Controls<Selected, Ending> = {
         exit(ending: Ending) {

--- a/packages/store-follow/src/types.ts
+++ b/packages/store-follow/src/types.ts
@@ -1,5 +1,4 @@
 import type { MessageQueue } from "@watchable/queue";
-import type { Immutable } from "@watchable/store";
 
 /** Function to process a queue of values including an initial starting value, leading to
  * a final `Ending` result.
@@ -11,7 +10,7 @@ export type QueueHandler<Selected, Ending> = (
 
 /** A function to notify a series of changing values from a store. */
 export type Follower<Selected, Ending> = (
-  selected: Immutable<Selected>,
+  selected: Selected,
   controlHandle: Controls<Selected, Ending>
   // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 ) => Promise<void | ExitStatus>;
@@ -20,7 +19,7 @@ export type Follower<Selected, Ending> = (
  * exit behaviour, retrieve references.
  */
 export interface Controls<Selected, Ending> {
-  lastSelected: () => Immutable<Selected> | undefined;
+  lastSelected: () => Selected | undefined;
   exit: (ending: Ending) => ExitStatus;
 }
 

--- a/packages/store/src/types/store.ts
+++ b/packages/store/src/types/store.ts
@@ -54,7 +54,7 @@ export type RootState = object;
  * changed, defining when app logic should be re-run. */
 export type Selector<State extends RootState, Selected> = (
   state: Immutable<State>
-) => Immutable<Selected>;
+) => Selected;
 
 /** An item satisfying type constraints of {@link RootState} but where a child item
  * at `Key` ***also*** satisfies `RootState`. A Store with a


### PR DESCRIPTION
Wrapping inferred `Selected` itself in a further `Immutable` is unnecessary and problematic. 

If the return type of the `Selector` is `Immutable` when passed an `Immutable<State>`, then it will be inferred as such. In practice wrapping `Selected` in `Immutable` ends up with cases where some `T` or `Immutable<T>` ends up being assigned to `Immutable<Immutable<T>>` which throws errors.

