### PR TITLE
Create read/write utility hook like React useState

### DIFF
--- a/.changeset/red-crabs-buy.md
+++ b/.changeset/red-crabs-buy.md
@@ -1,0 +1,6 @@
+---
+"@watchable/store-react": patch
+"@watchable/store": patch
+---
+
+Loosen RootState type. Add useStateProperty hook.

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,11 +46,11 @@
       }
     },
     "apps/counter-dom-commonjs": {
-      "version": "0.9.0-alpha.3",
+      "version": "0.9.0-alpha.5",
       "license": "MIT",
       "dependencies": {
-        "@watchable/store": "0.9.0-alpha.3",
-        "@watchable/store-follow": "0.9.0-alpha.3"
+        "@watchable/store": "1.0.0-alpha.5",
+        "@watchable/store-follow": "1.0.0-alpha.5"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^24.1.0",
@@ -139,11 +139,11 @@
       }
     },
     "apps/counter-dom-esm": {
-      "version": "0.9.0-alpha.3",
+      "version": "0.9.0-alpha.5",
       "license": "MIT",
       "dependencies": {
-        "@watchable/store": "0.9.0-alpha.3",
-        "@watchable/store-follow": "0.9.0-alpha.3"
+        "@watchable/store": "1.0.0-alpha.5",
+        "@watchable/store-follow": "1.0.0-alpha.5"
       },
       "devDependencies": {
         "@vitejs/plugin-legacy": "^4.0.2",
@@ -230,10 +230,10 @@
       }
     },
     "apps/counter-dom-tiny": {
-      "version": "0.9.0-alpha.3",
+      "version": "0.9.0-alpha.5",
       "license": "MIT",
       "dependencies": {
-        "@watchable/store": "0.9.0-alpha.3"
+        "@watchable/store": "1.0.0-alpha.5"
       },
       "devDependencies": {
         "vite": "^4.2.1",
@@ -297,11 +297,11 @@
       }
     },
     "apps/counter-dom-ts": {
-      "version": "0.9.0-alpha.3",
+      "version": "0.9.0-alpha.5",
       "license": "MIT",
       "dependencies": {
-        "@watchable/store": "0.9.0-alpha.3",
-        "@watchable/store-follow": "0.9.0-alpha.3"
+        "@watchable/store": "1.0.0-alpha.5",
+        "@watchable/store-follow": "1.0.0-alpha.5"
       },
       "devDependencies": {
         "@vitejs/plugin-legacy": "^4.0.2",
@@ -389,11 +389,11 @@
       }
     },
     "apps/counter-preact-ts": {
-      "version": "0.9.0-alpha.3",
+      "version": "0.9.0-alpha.5",
       "license": "MIT",
       "dependencies": {
-        "@watchable/store": "0.9.0-alpha.3",
-        "@watchable/store-react": "0.9.0-alpha.3",
+        "@watchable/store": "1.0.0-alpha.5",
+        "@watchable/store-react": "1.0.0-alpha.5",
         "react": "npm:@preact/compat",
         "react-dom": "npm:@preact/compat"
       },
@@ -528,11 +528,11 @@
       }
     },
     "apps/counter-react-js": {
-      "version": "0.9.0-alpha.3",
+      "version": "0.9.0-alpha.5",
       "license": "MIT",
       "dependencies": {
-        "@watchable/store": "0.9.0-alpha.3",
-        "@watchable/store-react": "0.9.0-alpha.3",
+        "@watchable/store": "1.0.0-alpha.5",
+        "@watchable/store-react": "1.0.0-alpha.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "vite-plugin-react": "^4.0.1"
@@ -687,11 +687,11 @@
       }
     },
     "apps/counter-react-ts": {
-      "version": "0.9.0-alpha.3",
+      "version": "0.9.0-alpha.5",
       "license": "MIT",
       "dependencies": {
-        "@watchable/store": "0.9.0-alpha.3",
-        "@watchable/store-react": "0.9.0-alpha.3",
+        "@watchable/store": "1.0.0-alpha.5",
+        "@watchable/store-react": "1.0.0-alpha.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -710,12 +710,12 @@
       }
     },
     "apps/counter-react-ts-edit": {
-      "version": "0.9.0-alpha.3",
+      "version": "0.9.0-alpha.5",
       "license": "MIT",
       "dependencies": {
-        "@watchable/store": "0.9.0-alpha.3",
-        "@watchable/store-edit": "0.9.0-alpha.3",
-        "@watchable/store-react": "0.9.0-alpha.3",
+        "@watchable/store": "1.0.0-alpha.5",
+        "@watchable/store-edit": "1.0.0-alpha.5",
+        "@watchable/store-react": "1.0.0-alpha.5",
         "immer": "^10.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -736,12 +736,12 @@
       }
     },
     "apps/counter-react-ts-edit-context": {
-      "version": "0.9.0-alpha.3",
+      "version": "0.9.0-alpha.5",
       "license": "MIT",
       "dependencies": {
-        "@watchable/store": "0.9.0-alpha.3",
-        "@watchable/store-edit": "0.9.0-alpha.3",
-        "@watchable/store-react": "0.9.0-alpha.3",
+        "@watchable/store": "1.0.0-alpha.5",
+        "@watchable/store-edit": "1.0.0-alpha.5",
+        "@watchable/store-react": "1.0.0-alpha.5",
         "immer": "^10.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -1125,10 +1125,10 @@
       }
     },
     "apps/fast": {
-      "version": "0.9.0-alpha.3",
+      "version": "0.9.0-alpha.5",
       "license": "MIT",
       "dependencies": {
-        "@watchable/store": "0.9.0-alpha.3"
+        "@watchable/store": "1.0.0-alpha.5"
       },
       "devDependencies": {
         "@vitejs/plugin-legacy": "^4.0.3",
@@ -1234,10 +1234,10 @@
       }
     },
     "apps/tiny": {
-      "version": "0.9.0-alpha.3",
+      "version": "0.9.0-alpha.5",
       "license": "MIT",
       "dependencies": {
-        "@watchable/store": "0.9.0-alpha.3"
+        "@watchable/store": "1.0.0-alpha.5"
       },
       "devDependencies": {
         "vite": "^4.2.1",
@@ -12185,7 +12185,7 @@
     },
     "packages/queue": {
       "name": "@watchable/queue",
-      "version": "0.9.0-alpha.3",
+      "version": "1.0.0-alpha.5",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.0.4",
@@ -12252,7 +12252,7 @@
     },
     "packages/store": {
       "name": "@watchable/store",
-      "version": "0.9.0-alpha.3",
+      "version": "1.0.0-alpha.5",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.0.4",
@@ -12263,10 +12263,10 @@
     },
     "packages/store-edit": {
       "name": "@watchable/store-edit",
-      "version": "0.9.0-alpha.3",
+      "version": "1.0.0-alpha.5",
       "license": "MIT",
       "dependencies": {
-        "@watchable/store": "0.9.0-alpha.3",
+        "@watchable/store": "1.0.0-alpha.5",
         "immer": "^9.0.16 || ^10.0.1"
       },
       "devDependencies": {
@@ -12276,7 +12276,7 @@
         "wireit": "^0.9.5"
       },
       "peerDependencies": {
-        "@watchable/store": "0.9.0-alpha.3",
+        "@watchable/store": "1.0.0-alpha.5",
         "immer": "^9.0.16 || ^10.0.1"
       }
     },
@@ -12338,11 +12338,11 @@
     },
     "packages/store-follow": {
       "name": "@watchable/store-follow",
-      "version": "0.9.0-alpha.3",
+      "version": "1.0.0-alpha.5",
       "license": "MIT",
       "dependencies": {
-        "@watchable/queue": "0.9.0-alpha.3",
-        "@watchable/store": "0.9.0-alpha.3"
+        "@watchable/queue": "1.0.0-alpha.5",
+        "@watchable/store": "1.0.0-alpha.5"
       },
       "devDependencies": {
         "typescript": "^5.0.4",
@@ -12350,8 +12350,8 @@
         "wireit": "^0.9.5"
       },
       "peerDependencies": {
-        "@watchable/queue": "0.9.0-alpha.3",
-        "@watchable/store": "0.9.0-alpha.3"
+        "@watchable/queue": "1.0.0-alpha.5",
+        "@watchable/store": "1.0.0-alpha.5"
       }
     },
     "packages/store-follow/node_modules/@types/node": {
@@ -12412,10 +12412,10 @@
     },
     "packages/store-react": {
       "name": "@watchable/store-react",
-      "version": "0.9.0-alpha.3",
+      "version": "1.0.0-alpha.5",
       "license": "MIT",
       "dependencies": {
-        "@watchable/store": "0.9.0-alpha.3"
+        "@watchable/store": "1.0.0-alpha.5"
       },
       "devDependencies": {
         "@testing-library/dom": "^9.2.0",
@@ -12429,7 +12429,7 @@
         "wireit": "^0.9.5"
       },
       "peerDependencies": {
-        "@watchable/store": "0.9.0-alpha.3",
+        "@watchable/store": "1.0.0-alpha.5",
         "react": "^18.2.0"
       }
     },

--- a/packages/store-edit/src/edit.ts
+++ b/packages/store-edit/src/edit.ts
@@ -15,6 +15,6 @@ export function edit<State extends RootState>(
 ) {
   const nextState = produce<State>(store.read() as State, (draft) => {
     editor(draft);
-  }) as unknown as Immutable<State>;
+  }) as Immutable<State>;
   return store.write(nextState);
 }

--- a/packages/store/src/lib/partition.ts
+++ b/packages/store/src/lib/partition.ts
@@ -33,14 +33,12 @@ class DefaultStorePartition<
         return;
       }
       lastSubState = subState;
-      void this.notify(subState as unknown as Immutable<ParentState[Key]>);
+      void this.notify(subState as Immutable<ParentState[Key]>);
     });
   };
 
   read = () => {
-    return this.store.read()[this.key] as unknown as Immutable<
-      ParentState[Key]
-    >;
+    return this.store.read()[this.key] as Immutable<ParentState[Key]>;
   };
 
   write = (state: Immutable<ParentState[Key]>) => {

--- a/packages/store/src/types/store.ts
+++ b/packages/store/src/types/store.ts
@@ -43,10 +43,11 @@ import type { WatchableState } from "./watchable";
  */
 export type Store<State extends RootState> = WatchableState<Immutable<State>>;
 
-/** Defines the set of possible state types for a {@link Store},
- * usually the top level State 'container' is either an
- * Array, Tuple, or keyed Object */
-export type RootState = object;
+/** Defines the set of possible state types for a {@link Store}. Now permits
+ * any value. However, usually the top level State 'container' is either an
+ * Array, Tuple, or other keyed Object (primitive values are already
+ * Immutable in javascript). */
+export type RootState = unknown;
 
 /** A Selector derives some sub-part or computed value from a {@link RootState} in a
  * @watchable/store {@link Store}. `Object.is(prev, next)` is normally used to compare
@@ -73,5 +74,6 @@ export type Selector<State extends RootState, Selected> = (
  *
  * See also {@link createStorePartition}.
  */
-export type PartitionableState<Key extends string | number | symbol> =
-  RootState & { [k in Key]: RootState };
+export type PartitionableState<Key extends PropertyKey> = object & {
+  [k in Key]: RootState;
+};

--- a/packages/store/test/storeSuite.ts
+++ b/packages/store/test/storeSuite.ts
@@ -14,14 +14,52 @@ export function createStoreSuite(
   storeFactory: StoreFactory
 ) {
   describe(`${suiteName}: Core behaviour`, () => {
-    test("Create Store with list root", () => {
-      const state = [3, 4, 5];
-      expect(storeFactory<number[]>(state).read()).toEqual(state);
+    test("Create Store with Array root", () => {
+      const state: number[] = [3, 4, 5];
+      expect(storeFactory<typeof state>(state).read()).toEqual(state);
     });
 
-    test("Create Store with map root", () => {
-      const state = { pi: 3.1415926 };
-      expect(storeFactory<Record<string, number>>(state).read()).toEqual(state);
+    test("Create Store with Record root", () => {
+      const state: Record<string, number> = { pi: 3.1415926 };
+      expect(storeFactory<typeof state>(state).read()).toEqual(state);
+    });
+
+    test("Create Store with string root", () => {
+      const state: string = "hello world";
+      expect(storeFactory<typeof state>(state).read()).toEqual(state);
+    });
+
+    test("Create Store with number root", () => {
+      const state: number = 42;
+      expect(storeFactory<typeof state>(state).read()).toEqual(state);
+    });
+
+    test("Create Store with boolean root", () => {
+      const state: boolean = true;
+      expect(storeFactory<boolean>(state).read()).toEqual(state);
+    });
+
+    test("Create Store with null root", () => {
+      // a null root is not normal but this test
+      // should reveal issues with the now very broad typing of RootState
+      const state = null;
+      expect(storeFactory<null>(state).read()).toEqual(state);
+    });
+
+    test("Create Store with undefined root", () => {
+      // an undefined root is not normal but this test
+      // should reveal issues with the now very broad typing of RootState
+      const state = undefined;
+      // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+      expect(storeFactory<typeof state>(state).read()).toEqual(state);
+    });
+
+    test("Store with optional root handles state transition to undefined", () => {
+      let state = "foo" satisfies string | undefined as string | undefined;
+      const store = storeFactory<typeof state>(state);
+      expect(store.read()).toEqual(state);
+      state = undefined;
+      store.write(state);
     });
 
     test("Create Store and pass watchers who are notified", async () => {


### PR DESCRIPTION
I take it from https://github.com/cefn/watchable/issues/37 that a signature having the capabilities of `React.useState` to permit reading and writing of a value within Store state would be valuable.

The [useSelected](https://watchable.dev/api/functions/_watchable_store_react.useSelected.html) hook easily permits retrieving any property from the state, but this doesn't assist with a setter definition, which is impossible to derive from a selector which is just a black-box function.

The natural primitive operation (at least until path support is introduced) is to use a key from one of the state's child properties which can define BOTH a selector and a setter.  

In this MR, we introduce a `useStateProperty` hook, with a signature similar to [useState](https://react.dev/reference/react/useState), driven by a keyed property of the Store state. Draft implementation is [here](https://github.com/cefn/watchable/blob/ISSUE35-read-write-primitive/packages/store-react/src/index.ts#L83) and tests are [here](https://github.com/cefn/watchable/blob/ISSUE35-read-write-primitive/packages/store-react/test/index.test.tsx#L302)

For example this would display first `red` then `white` after the useEffect change of state has triggered a futher render...

```ts
      const store = createStore({ roses: "red" });
      const Component = () => {
        const [roseColor, setRoseColor] = useStateProperty(store, "roses");
        useEffect(() => {
          setRoseColor("white");
        }, []);
        return <p>{roseColor}</p>;
      };
```

## Alternative: Using createStorePartition() 

It is not suitable to use [createStorePartition](https://cefn.com/lauf/api/functions/_lauf_store.createStorePartition.html) as a backing implementation, even though this seems promising since you can pick an individual property, read it and write it using the partitioned `Store` read/write methods. That's because it comes with a lot of overhead (creates a whole store, with its own listener list, and irreversibly subscribes the store to the parent store). 

As summarised [here](https://cefn.com/lauf/api/types/_lauf_store.PartitionableState.html) the store-partitioning pattern is intended much more for single-responsibility and interface-segregation. It means components can consume a complete store interface (including watch) without knowing that it's actually a sub-part of a larger Store, and multiple subscribers can then benefit from the efficiency of having ALL their watch subscriptions eliminated by a single check (that **_their_** partition of the store hasn't changed). 

These aren't requirements of the case described by https://github.com/cefn/watchable/issues/37 

Also until the implementation of https://github.com/cefn/watchable/issues/36 the creation of store partitions can't be undone (there is no destroy that detaches watchers) meaning this kind of derived state is poorly managed as part of a React render and could lead to memory leaks. 

Closes #37 