### PR TITLE
Improvements to store-react useSelected

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,11 +46,11 @@
       }
     },
     "apps/counter-dom-commonjs": {
-      "version": "0.9.0-alpha.5",
+      "version": "0.9.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@watchable/store": "1.0.0-alpha.5",
-        "@watchable/store-follow": "1.0.0-alpha.5"
+        "@watchable/store": "1.0.0-alpha.6",
+        "@watchable/store-follow": "1.0.0-alpha.6"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^24.1.0",
@@ -547,11 +547,11 @@
       }
     },
     "apps/counter-dom-esm": {
-      "version": "0.9.0-alpha.5",
+      "version": "0.9.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@watchable/store": "1.0.0-alpha.5",
-        "@watchable/store-follow": "1.0.0-alpha.5"
+        "@watchable/store": "1.0.0-alpha.6",
+        "@watchable/store-follow": "1.0.0-alpha.6"
       },
       "devDependencies": {
         "@vitejs/plugin-legacy": "^4.0.2",
@@ -1046,10 +1046,10 @@
       }
     },
     "apps/counter-dom-tiny": {
-      "version": "0.9.0-alpha.5",
+      "version": "0.9.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@watchable/store": "1.0.0-alpha.5"
+        "@watchable/store": "1.0.0-alpha.6"
       },
       "devDependencies": {
         "vite": "^4.2.1",
@@ -1512,11 +1512,11 @@
       }
     },
     "apps/counter-dom-ts": {
-      "version": "0.9.0-alpha.5",
+      "version": "0.9.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@watchable/store": "1.0.0-alpha.5",
-        "@watchable/store-follow": "1.0.0-alpha.5"
+        "@watchable/store": "1.0.0-alpha.6",
+        "@watchable/store-follow": "1.0.0-alpha.6"
       },
       "devDependencies": {
         "@vitejs/plugin-legacy": "^4.0.2",
@@ -2012,11 +2012,11 @@
       }
     },
     "apps/counter-preact-ts": {
-      "version": "0.9.0-alpha.5",
+      "version": "0.9.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@watchable/store": "1.0.0-alpha.5",
-        "@watchable/store-react": "1.0.0-alpha.5",
+        "@watchable/store": "1.0.0-alpha.6",
+        "@watchable/store-react": "1.0.0-alpha.6",
         "react": "npm:@preact/compat",
         "react-dom": "npm:@preact/compat"
       },
@@ -2559,11 +2559,11 @@
       }
     },
     "apps/counter-react-js": {
-      "version": "0.9.0-alpha.5",
+      "version": "0.9.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@watchable/store": "1.0.0-alpha.5",
-        "@watchable/store-react": "1.0.0-alpha.5",
+        "@watchable/store": "1.0.0-alpha.6",
+        "@watchable/store-react": "1.0.0-alpha.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "vite-plugin-react": "^4.0.1"
@@ -3103,11 +3103,11 @@
       }
     },
     "apps/counter-react-ts": {
-      "version": "0.9.0-alpha.5",
+      "version": "0.9.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@watchable/store": "1.0.0-alpha.5",
-        "@watchable/store-react": "1.0.0-alpha.5",
+        "@watchable/store": "1.0.0-alpha.6",
+        "@watchable/store-react": "1.0.0-alpha.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -3126,12 +3126,12 @@
       }
     },
     "apps/counter-react-ts-edit": {
-      "version": "0.9.0-alpha.5",
+      "version": "0.9.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@watchable/store": "1.0.0-alpha.5",
-        "@watchable/store-edit": "1.0.0-alpha.5",
-        "@watchable/store-react": "1.0.0-alpha.5",
+        "@watchable/store": "1.0.0-alpha.6",
+        "@watchable/store-edit": "1.0.0-alpha.6",
+        "@watchable/store-react": "1.0.0-alpha.6",
         "immer": "^10.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -3152,12 +3152,12 @@
       }
     },
     "apps/counter-react-ts-edit-context": {
-      "version": "0.9.0-alpha.5",
+      "version": "0.9.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@watchable/store": "1.0.0-alpha.5",
-        "@watchable/store-edit": "1.0.0-alpha.5",
-        "@watchable/store-react": "1.0.0-alpha.5",
+        "@watchable/store": "1.0.0-alpha.6",
+        "@watchable/store-edit": "1.0.0-alpha.6",
+        "@watchable/store-react": "1.0.0-alpha.6",
         "immer": "^10.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -4765,10 +4765,10 @@
       }
     },
     "apps/fast": {
-      "version": "0.9.0-alpha.5",
+      "version": "0.9.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@watchable/store": "1.0.0-alpha.5"
+        "@watchable/store": "1.0.0-alpha.6"
       },
       "devDependencies": {
         "@vitejs/plugin-legacy": "^4.0.3",
@@ -5283,10 +5283,10 @@
       }
     },
     "apps/tiny": {
-      "version": "0.9.0-alpha.5",
+      "version": "0.9.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@watchable/store": "1.0.0-alpha.5"
+        "@watchable/store": "1.0.0-alpha.6"
       },
       "devDependencies": {
         "vite": "^4.2.1",
@@ -18933,7 +18933,7 @@
     },
     "packages/store": {
       "name": "@watchable/store",
-      "version": "1.0.0-alpha.5",
+      "version": "1.0.0-alpha.6",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.0.4",
@@ -18944,10 +18944,10 @@
     },
     "packages/store-edit": {
       "name": "@watchable/store-edit",
-      "version": "1.0.0-alpha.5",
+      "version": "1.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@watchable/store": "1.0.0-alpha.5",
+        "@watchable/store": "1.0.0-alpha.6",
         "immer": "^9.0.16 || ^10.0.1"
       },
       "devDependencies": {
@@ -18957,7 +18957,7 @@
         "wireit": "^0.9.5"
       },
       "peerDependencies": {
-        "@watchable/store": "1.0.0-alpha.5",
+        "@watchable/store": "1.0.0-alpha.6",
         "immer": "^9.0.16 || ^10.0.1"
       }
     },
@@ -19418,11 +19418,11 @@
     },
     "packages/store-follow": {
       "name": "@watchable/store-follow",
-      "version": "1.0.0-alpha.5",
+      "version": "1.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
         "@watchable/queue": "1.0.0-alpha.5",
-        "@watchable/store": "1.0.0-alpha.5"
+        "@watchable/store": "1.0.0-alpha.6"
       },
       "devDependencies": {
         "typescript": "^5.0.4",
@@ -19431,7 +19431,7 @@
       },
       "peerDependencies": {
         "@watchable/queue": "1.0.0-alpha.5",
-        "@watchable/store": "1.0.0-alpha.5"
+        "@watchable/store": "1.0.0-alpha.6"
       }
     },
     "packages/store-follow/node_modules/@esbuild/android-arm": {
@@ -19891,10 +19891,10 @@
     },
     "packages/store-react": {
       "name": "@watchable/store-react",
-      "version": "1.0.0-alpha.5",
+      "version": "1.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@watchable/store": "1.0.0-alpha.5"
+        "@watchable/store": "1.0.0-alpha.6"
       },
       "devDependencies": {
         "@testing-library/dom": "^9.2.0",
@@ -19908,7 +19908,7 @@
         "wireit": "^0.9.5"
       },
       "peerDependencies": {
-        "@watchable/store": "1.0.0-alpha.5",
+        "@watchable/store": "1.0.0-alpha.6",
         "react": "^18.2.0"
       }
     },

--- a/packages/store-react/test/index.test.tsx
+++ b/packages/store-react/test/index.test.tsx
@@ -353,18 +353,16 @@ describe("store-react :", () => {
         }, []);
         return <p>{value}</p>;
       };
+      // bind component
       render(<Component />);
+      // validate first render
       screen.getByText("red");
       expect(renderSpy).toHaveBeenCalledTimes(1);
       renderSpy.mockClear();
-      await eventsDueCompleted(); // await for useEffect to set Rendered Key
-      await eventsDueCompleted(); // await for consequent render
-      // expect the component to render the different keyed property
+      // wait for useEffect key change to propagate
+      await eventsDueCompleted();
+      expect(renderSpy).toHaveBeenCalledTimes(1);
       screen.getByText("blue");
-      // render will have been triggered twice more
-      // once after useEffect changed key (passed to the useStateProperty call)
-      // once more for the useSelected inside useStateProperty to propagate its internal state
-      expect(renderSpy).toHaveBeenCalledTimes(2);
     });
 
     test("ignores untracked property of store", async () => {


### PR DESCRIPTION
## Liveness

In this reworked implementation, the selected value is always 'derived' from props inline in the render. This means the render has the very latest value of `selected`.  

Previously the updating of selected was handled via a `setState` that was wired up in a `useEffect` hook which put state propagation outside the render. 

In the worst circumstances, (for example if an earlier-subscribed watcher had already triggered a synchronous render before later watchers executed), a later watcher's state changes would require a further render, and the state wouldn't be updated until the later render.

The same effect occurred when the selector was defined as a callback dependent on some component props - rather than immediately affecting state, the change of selector would simply invalidate the `useEffect` meaning the eventual state change would only propagate after the render.

With this new implementation, the render itself recomputes the selected. If the render has already run, it will have already derived selected state, and synchronized it to the React tree. When notified, since it shares a memoized version of the selector  the watcher detects there is no more work to do, and doesn't trigger a render. This means state changes propagate quicker and more predictably, and fewer renders are needed for these edge cases.

## 'Caching' computed values

`useSelected` didn't previously wrap your selector function in a memoizing wrapper (guaranteeing the same return given the same state). 

Memoization is a subtle art for less confident React developers. Since memoization of a single arg function is very lightweight and easy to implement, and is a requirement for the change to state propagation above, this is now added by default. 

Now if your selector and the state are identical since the last execution, then `useSelected` will return the previous value.

Crucially this eliminates the case where derived computed values give a new unique value on every render, even when the underlying state hadn't changed. 

For example, if you wrote a hook like this, it would force any component that consumed the summary value to re-render, even when nothing had changed, because it constructs a new object every time.

```ts
type State = Immutable<{
  charges:number[]
}>

function summarySelector(state:State){
  const { charges } = state;
  return {
       count: charges.length, 
       total: charges.reduce((acc, charge) => acc + charge, 0)
  } as const;
}

function useSummary(store: Store<State>){
  return useSelected(store, summarySelector)
}
```

With the new implementation, `summarySelector` is only re-executed if it or the state has actually changed. Until then, the first `summary` object is used. 