### PR TITLE
Treat functions as executors

### DIFF
--- a/packages/unpromise/src/unpromise.ts
+++ b/packages/unpromise/src/unpromise.ts
@@ -80,10 +80,10 @@ export class Unpromise<T> implements ProxyPromise<T> {
   protected constructor(promise: Promise<T>);
   protected constructor(arg: Promise<T> | PromiseExecutor<T>) {
     // handle either a Promise or a Promise executor function
-    if (arg instanceof Promise) {
-      this.promise = arg;
-    } else {
+    if (typeof arg === "function") {
       this.promise = new Promise(arg);
+    } else {
+      this.promise = arg;
     }
 
     // subscribe for eventual fulfilment and rejection


### PR DESCRIPTION
In https://github.com/cefn/watchable/issues/62 @davidfiala reported that some thenables (which were not strictly `instanceof Promise`) were taking the wrong path in the constructor arg to Unpromise. They ended up being interpreted as an executor function instead leading to bugs.

In this PR the check is inverted and is therefore a bit more safe. It won't mistakenly treat a non-function as a Promise executor.