### PR TITLE
Release changeset

### DIFF
--- a/packages/unpromise/CHANGELOG.md
+++ b/packages/unpromise/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @watchable/unpromise
 
+## 1.0.1
+
+### Patch Changes
+
+- Fix array signature to race and any.
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/unpromise/package.json
+++ b/packages/unpromise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@watchable/unpromise",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Promise with unsubscribe feature that minimises memory leaks",
   "keywords": [
     "Promise.race",


### PR DESCRIPTION
Release improved `unpromise` types to address further issues described in https://github.com/cefn/watchable/issues/62

Closes #62 